### PR TITLE
handle auth_data

### DIFF
--- a/lib/wax_demo_web/controllers/credential_controller.ex
+++ b/lib/wax_demo_web/controllers/credential_controller.ex
@@ -48,8 +48,11 @@ defmodule WaxDemoWeb.CredentialController do
     sig = Base.decode64!(sig_b64)
 
     case Wax.authenticate(raw_id_b64, authenticator_data, sig, client_data_json, challenge) do
-      {:ok, _} ->
+      {:ok, _sign_count, auth_data} ->
         Logger.debug("Wax: successful authentication for challenge #{inspect(challenge)}")
+
+        # auth_data.flag_user_present
+        # if auth_data.flag_user_verified 
 
         conn
         |> put_session(:authenticated, true)

--- a/lib/wax_demo_web/controllers/register_key_controller.ex
+++ b/lib/wax_demo_web/controllers/register_key_controller.ex
@@ -37,12 +37,15 @@ defmodule WaxDemoWeb.RegisterKeyController do
     attestation_object = Base.decode64!(attestation_object_b64)
 
     case Wax.register(attestation_object, client_data_json, challenge) do
-      {:ok, {cose_key, attestation_result}} ->
+      {:ok, {cose_key, attestation_result, auth_data}} ->
         Logger.debug(
           "Wax: attestation object validated with cose key #{inspect(cose_key)} " <>
             " and attestation result #{inspect(attestation_result)}"
         )
 
+        # auth_data.flag_user_present
+        # if auth_data.flag_user_verified
+        
         user = get_session(conn, :login)
 
         WaxDemo.User.register_new_cose_key(user, raw_id_b64, cose_key)

--- a/lib/wax_demo_web/templates/credential/credential.html.eex
+++ b/lib/wax_demo_web/templates/credential/credential.html.eex
@@ -85,7 +85,8 @@ function triggerAuthenticate(){
           transports: ["usb", "nfc", "ble"]
         },
       <% end %>
-      ]
+      ],
+      userVerification: "preferred",
     }
   }).then(function (newCredential) {
     document.getElementById('rawID').value = _arrayBufferToBase64(newCredential.rawId);

--- a/lib/wax_demo_web/templates/register_key/register_key.html.eex
+++ b/lib/wax_demo_web/templates/register_key/register_key.html.eex
@@ -84,7 +84,11 @@ function triggerAttestation(){
           type: "public-key", alg: -7 // "ES256" IANA COSE Algorithms registry
         }
       ],
-      attestation: attestation_conveyance_preference
+      attestation: attestation_conveyance_preference,
+      // https://w3c.github.io/webauthn/#authenticatorSelection
+      authenticatorSelection: {
+        userVerification: "preferred"
+      }
     }
   }).then(function (newCredential) {
     document.getElementById('rawID').value = _arrayBufferToBase64(newCredential.rawId);


### PR DESCRIPTION
requires: https://github.com/tanguilp/wax/pull/6

This breaks the API, so ideally you could bump the `Wax` version and make that a requirement for this demo.